### PR TITLE
fix "Illegal invocation" error in Chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ Tick.prototype.setTimeout = function timeout(name, fn, time) {
 
   tick.timers[name] = {
     timer: setTimeout(tick.tock(name, true), ms(time)),
-    clear: clearTimeout,
+    clear: function(id) { clearTimeout(id); },
     fns: [fn]
   };
 
@@ -90,7 +90,7 @@ Tick.prototype.setInterval = function interval(name, fn, time) {
 
   tick.timers[name] = {
     timer: setInterval(tick.tock(name), ms(time)),
-    clear: clearInterval.bind(null),
+    clear: function(id) { clearInterval(id); },
     fns: [fn]
   };
 
@@ -117,7 +117,7 @@ Tick.prototype.setImmediate = function immediate(name, fn) {
 
   tick.timers[name] = {
     timer: setImmediate(tick.tock(name, true)),
-    clear: clearImmediate,
+    clear: function(id) { clearImmediate(id); },
     fns: [fn]
   };
 

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ Tick.prototype.setInterval = function interval(name, fn, time) {
 
   tick.timers[name] = {
     timer: setInterval(tick.tock(name), ms(time)),
-    clear: clearInterval,
+    clear: clearInterval.bind(null),
     fns: [fn]
   };
 


### PR DESCRIPTION
I noticed this while trying Liferaft in the browser. Calling `clearTimeout` like `timer.clear` changes the binding of `this` and causes an error in Chrome, but I'm not sure why or if this happens in other browsers. Binding `clearTimeout` to `null` seems to fix it. 

Note: this fails the code coverage precommit hook, not sure how to best test this with the current mocha setup.
